### PR TITLE
Specified the encoding to be used

### DIFF
--- a/migra/command.py
+++ b/migra/command.py
@@ -57,7 +57,7 @@ def run(args, out=None, err=None):
 
         try:
             if m.statements:
-                print(m.sql, file=out)
+                print(m.sql.encode('utf-8'), file=out)
         except UnsafeMigrationException:
             print('-- ERROR: destructive statements generated. Use the --unsafe flag to suppress this error.', file=err)
             return 3


### PR DESCRIPTION
This pull request fixes the following error which I encountered using the windows command prompt and also Windows PowerShell:

`Traceback (most recent call last):
  File "c:\python34\lib\runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python34\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python34\Scripts\migra.exe\__main__.py", line 9, in <module>
  File "c:\python34\lib\site-packages\migra\command.py", line 73, in do_command
    status = run(args)
  File "c:\python34\lib\site-packages\migra\command.py", line 60, in run
    print(m.sql, file=out)
  File "c:\python34\lib\encodings\cp437.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_map)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\xf8' in position 27818: character maps to <undefined>`

I got the solution used here, from this answer:
https://stackoverflow.com/a/492711/163461

I have not tested this fix if writing to a file instead of stdout, not have I tested it on other operating systems than Windows.