### PR TITLE
Support privilege changes (initially only on tables)

### DIFF
--- a/migra/changes.py
+++ b/migra/changes.py
@@ -14,6 +14,7 @@ THINGS = [
     'views',
     'indexes',
     'extensions',
+    'privileges',
 ]
 PK = 'PRIMARY KEY'
 

--- a/migra/command.py
+++ b/migra/command.py
@@ -32,14 +32,21 @@ def parse_args(args):
         dest='schema',
         default=None,
         help='Restrict output to statements for a particular schema',
-    ),
+    )
     parser.add_argument(
         '--create-extensions-only',
         dest='create_extensions_only',
         action='store_true',
         default=False,
         help='Only output "create extension..." statements, nothing else.',
-    ),
+    )
+    parser.add_argument(
+        '--with-privileges',
+        dest='with_privileges',
+        action='store_true',
+        default=False,
+        help='Also output privilege differences (ie. grant/revoke statements)',
+    )
     parser.add_argument('dburl_from', help='The database you want to migrate.')
     parser.add_argument(
         'dburl_target', help='The database you want to use as the target.'
@@ -60,7 +67,7 @@ def run(args, out=None, err=None):
         if args.create_extensions_only:
             m.add_extension_changes(drops=False)
         else:
-            m.add_all_changes()
+            m.add_all_changes(privileges=args.with_privileges)
         try:
             if m.statements:
                 print(m.sql, file=out)

--- a/migra/migra.py
+++ b/migra/migra.py
@@ -60,12 +60,13 @@ class Migration(object):
         if drops:
             self.add(self.changes.extensions(drops_only=True))
 
-    def add_all_changes(self):
+    def add_all_changes(self, privileges=False):
         self.add(self.changes.schemas(creations_only=True))
         self.add(self.changes.extensions(creations_only=True))
         self.add(self.changes.enums(creations_only=True, modifications=False))
         self.add(self.changes.sequences(creations_only=True))
-        self.add(self.changes.privileges(drops_only=True))
+        if privileges:
+            self.add(self.changes.privileges(drops_only=True))
         self.add(self.changes.non_pk_constraints(drops_only=True))
         self.add(self.changes.pk_constraints(drops_only=True))
         self.add(self.changes.indexes(drops_only=True))
@@ -85,7 +86,8 @@ class Migration(object):
         self.add(self.changes.indexes(creations_only=True))
         self.add(self.changes.pk_constraints(creations_only=True))
         self.add(self.changes.non_pk_constraints(creations_only=True))
-        self.add(self.changes.privileges(creations_only=True))
+        if privileges:
+            self.add(self.changes.privileges(creations_only=True))
         self.add(self.changes.schemas(drops_only=True))
 
     @property

--- a/migra/migra.py
+++ b/migra/migra.py
@@ -65,6 +65,7 @@ class Migration(object):
         self.add(self.changes.extensions(creations_only=True))
         self.add(self.changes.enums(creations_only=True, modifications=False))
         self.add(self.changes.sequences(creations_only=True))
+        self.add(self.changes.privileges(drops_only=True))
         self.add(self.changes.non_pk_constraints(drops_only=True))
         self.add(self.changes.pk_constraints(drops_only=True))
         self.add(self.changes.indexes(drops_only=True))
@@ -84,6 +85,7 @@ class Migration(object):
         self.add(self.changes.indexes(creations_only=True))
         self.add(self.changes.pk_constraints(creations_only=True))
         self.add(self.changes.non_pk_constraints(creations_only=True))
+        self.add(self.changes.privileges(creations_only=True))
         self.add(self.changes.schemas(drops_only=True))
 
     @property

--- a/tests/FIXTURES/everything/a.sql
+++ b/tests/FIXTURES/everything/a.sql
@@ -42,6 +42,8 @@ create index on products(price);
 
 create view vvv as select * from products;
 
+grant select, insert on table products to postgres;
+
 create or replace function public.changed(i integer, t text[])
 returns TABLE(a text, c integer) as
 $$

--- a/tests/FIXTURES/everything/b.sql
+++ b/tests/FIXTURES/everything/b.sql
@@ -25,6 +25,8 @@ CREATE TABLE products (
 
 create index on products(name);
 
+grant update, insert on table products to postgres;
+
 CREATE TABLE orders (
     order_id integer primary key unique,
     shipping_address text,

--- a/tests/FIXTURES/everything/expected.sql
+++ b/tests/FIXTURES/everything/expected.sql
@@ -10,6 +10,8 @@ create sequence "public"."bug_id_seq";
 
 create sequence "public"."products_product_no_seq";
 
+revoke select on table "public"."products" from postgres;
+
 alter table "public"."products" drop constraint "products_name_key";
 
 alter table "public"."products" drop constraint "products_x_key";
@@ -150,5 +152,7 @@ alter table "public"."order_items" add constraint "order_items_product_no_fkey" 
 alter table "public"."products" add constraint "y" CHECK ((price > (0)::numeric));
 
 alter table "public"."products" add constraint "x" CHECK ((price > (10)::numeric));
+
+grant update on table "public"."products" to postgres;
 
 drop schema if exists "badschema";

--- a/tests/FIXTURES/everything/expected.sql
+++ b/tests/FIXTURES/everything/expected.sql
@@ -133,11 +133,11 @@ drop type "public"."unwanted_enum";
 
 drop extension if exists "pg_trgm";
 
-CREATE UNIQUE INDEX order_items_pkey ON order_items USING btree (product_no, order_id);
+CREATE UNIQUE INDEX order_items_pkey ON public.order_items USING btree (product_no, order_id);
 
-CREATE INDEX products_name_idx ON products USING btree (name);
+CREATE INDEX products_name_idx ON public.products USING btree (name);
 
-CREATE UNIQUE INDEX products_pkey ON products USING btree (product_no);
+CREATE UNIQUE INDEX products_pkey ON public.products USING btree (product_no);
 
 alter table "public"."order_items" add constraint "order_items_pkey" PRIMARY KEY using index "order_items_pkey";
 

--- a/tests/FIXTURES/everything/expected2.sql
+++ b/tests/FIXTURES/everything/expected2.sql
@@ -129,11 +129,11 @@ drop type "public"."unwanted_enum";
 
 drop extension if exists "pg_trgm";
 
-CREATE UNIQUE INDEX order_items_pkey ON order_items USING btree (product_no, order_id);
+CREATE UNIQUE INDEX order_items_pkey ON public.order_items USING btree (product_no, order_id);
 
-CREATE INDEX products_name_idx ON products USING btree (name);
+CREATE INDEX products_name_idx ON public.products USING btree (name);
 
-CREATE UNIQUE INDEX products_pkey ON products USING btree (product_no);
+CREATE UNIQUE INDEX products_pkey ON public.products USING btree (product_no);
 
 alter table "public"."order_items" add constraint "order_items_pkey" PRIMARY KEY using index "order_items_pkey";
 

--- a/tests/FIXTURES/everything/expected2.sql
+++ b/tests/FIXTURES/everything/expected2.sql
@@ -10,6 +10,8 @@ create sequence "public"."bug_id_seq";
 
 create sequence "public"."products_product_no_seq";
 
+revoke select on table "public"."products" from postgres;
+
 alter table "public"."products" drop constraint "products_name_key";
 
 alter table "public"."products" drop constraint "products_x_key";
@@ -146,5 +148,7 @@ alter table "public"."order_items" add constraint "order_items_product_no_fkey" 
 alter table "public"."products" add constraint "y" CHECK ((price > (0)::numeric));
 
 alter table "public"."products" add constraint "x" CHECK ((price > (10)::numeric));
+
+grant update on table "public"."products" to postgres;
 
 drop schema if exists "badschema";

--- a/tests/FIXTURES/privileges/a.sql
+++ b/tests/FIXTURES/privileges/a.sql
@@ -1,0 +1,30 @@
+create extension pg_trgm;
+
+create schema any_schema;
+
+CREATE TYPE any_enum AS ENUM ('value1', 'value2');
+
+CREATE TABLE any_table (
+    id serial primary key,
+    name text not null
+);
+
+create unique index on any_table(name);
+
+create view any_view as select * from any_table;
+
+create view any_other_view as select * from any_table;
+
+create or replace function any_function(i integer, t text[])
+returns TABLE(a text, c integer) as
+$$
+ declare
+        BEGIN
+                select 'no', 1;
+        END;
+
+$$
+LANGUAGE PLPGSQL STABLE returns null on null input security definer;
+
+
+grant select, insert on table any_table to postgres;

--- a/tests/FIXTURES/privileges/additions.sql
+++ b/tests/FIXTURES/privileges/additions.sql
@@ -1,0 +1,3 @@
+grant delete on table any_table to postgres;
+
+revoke select on table any_table from postgres;

--- a/tests/FIXTURES/privileges/b.sql
+++ b/tests/FIXTURES/privileges/b.sql
@@ -1,0 +1,28 @@
+create extension pg_trgm;
+
+create schema any_schema;
+
+CREATE TYPE any_enum AS ENUM ('value1', 'value2');
+
+CREATE TABLE any_table (
+    id serial primary key,
+    name text not null
+);
+
+create unique index on any_table(name);
+
+create view any_view as select * from any_table;
+
+create or replace function any_function(i integer, t text[])
+returns TABLE(a text, c integer) as
+$$
+ declare
+        BEGIN
+                select 'no', 1;
+        END;
+
+$$
+LANGUAGE PLPGSQL STABLE returns null on null input security definer;
+
+
+grant update, insert on table any_table to postgres;

--- a/tests/FIXTURES/privileges/expected.sql
+++ b/tests/FIXTURES/privileges/expected.sql
@@ -1,0 +1,5 @@
+revoke select on table "public"."any_table" from postgres;
+
+drop view if exists "public"."any_other_view" cascade;
+
+grant update on table "public"."any_table" to postgres;

--- a/tests/FIXTURES/privileges/expected2.sql
+++ b/tests/FIXTURES/privileges/expected2.sql
@@ -1,0 +1,5 @@
+revoke delete on table "public"."any_table" from postgres;
+
+drop view if exists "public"."any_other_view" cascade;
+
+grant update on table "public"."any_table" to postgres;

--- a/tests/FIXTURES/singleschema/a.sql
+++ b/tests/FIXTURES/singleschema/a.sql
@@ -11,3 +11,5 @@ CREATE TYPE goodschema.sdfasdfasdf AS ENUM ('not shipped', 'shipped', 'delivered
 create index on goodschema.t(id);
 
 create view goodschema.v as select 1;
+
+grant select on table t to postgres;

--- a/tests/test_migra.py
+++ b/tests/test_migra.py
@@ -44,12 +44,14 @@ def test_with_fixtures():
         do_fixture_test(FIXTURE_NAME, create_extensions_only=True)
 
 
-def do_fixture_test(fixture_name, schema=None, create_extensions_only=False):
+def do_fixture_test(fixture_name, schema=None, create_extensions_only=False, with_privileges=False):
     flags = ['--unsafe']
     if schema:
         flags += ['--schema', schema]
     if create_extensions_only:
         flags += ['--create-extensions-only']
+    if with_privileges:
+        flags += ['--with-privileges']
     fixture_path = 'tests/FIXTURES/{}/'.format(fixture_name)
     EXPECTED = io.open(fixture_path + 'expected.sql').read().strip()
     with temporary_database() as d0, temporary_database() as d1:
@@ -82,11 +84,11 @@ def do_fixture_test(fixture_name, schema=None, create_extensions_only=False):
                 m.set_safety(False)
                 m.add_sql(ADDITIONS)
                 m.apply()
-                m.add_all_changes()
+                m.add_all_changes(privileges=with_privileges)
                 assert m.sql.strip() == EXPECTED2  # sql generated OK
                 m.apply()
                 # check for changes again and make sure none are pending
-                m.add_all_changes()
+                m.add_all_changes(privileges=with_privileges)
                 assert m.changes.i_from == m.changes.i_target
                 assert not m.statements  # no further statements to apply
                 assert m.sql == ''
@@ -97,7 +99,7 @@ def do_fixture_test(fixture_name, schema=None, create_extensions_only=False):
             m = Migration(get_inspector(s0), get_inspector(s1))
         # test empty
         m = Migration(None, None)
-        m.add_all_changes()
+        m.add_all_changes(privileges=with_privileges)
         with raises(AttributeError):
             m.s_from
         with raises(AttributeError):

--- a/tests/test_migra.py
+++ b/tests/test_migra.py
@@ -36,8 +36,10 @@ def outs():
 
 
 def test_with_fixtures():
-    for FIXTURE_NAME in ['dependencies', 'everything']:
+    for FIXTURE_NAME in ['dependencies']:
         do_fixture_test(FIXTURE_NAME)
+    for FIXTURE_NAME in ['everything']:
+        do_fixture_test(FIXTURE_NAME, with_privileges=True)
     for FIXTURE_NAME in ['singleschema']:
         do_fixture_test(FIXTURE_NAME, schema='goodschema')
     for FIXTURE_NAME in ['singleschema_ext']:

--- a/tests/test_migra.py
+++ b/tests/test_migra.py
@@ -42,6 +42,8 @@ def test_with_fixtures():
         do_fixture_test(FIXTURE_NAME, schema='goodschema')
     for FIXTURE_NAME in ['singleschema_ext']:
         do_fixture_test(FIXTURE_NAME, create_extensions_only=True)
+    for FIXTURE_NAME in ['privileges']:
+        do_fixture_test(FIXTURE_NAME, with_privileges=True)
 
 
 def do_fixture_test(fixture_name, schema=None, create_extensions_only=False, with_privileges=False):


### PR DESCRIPTION
Add `privileges` drops and creations to `Migration.add_all_changes()`.
Updated `everything` test to check grant/revoke statements are generated as expected.

Notes:
- I have also included #39's changes here so that we can know if tests are passing (at least on Python 3.6).
- This pull request depend on https://github.com/djrobstep/schemainspect/pull/9 (and a new version of schemainspect library to be released)