### PR TITLE
Add support for materialized views

### DIFF
--- a/migra/changes.py
+++ b/migra/changes.py
@@ -180,10 +180,12 @@ class Changes(object):
         elif name == "views_and_functions":
             av = self.i_from.views.items()
             bv = self.i_target.views.items()
+            am = self.i_from.materialized_views.items()
+            bm = self.i_target.materialized_views.items()
             af = self.i_from.functions.items()
             bf = self.i_target.functions.items()
-            avf = list(av) + list(af)
-            bvf = list(bv) + list(bf)
+            avf = list(av) + list(am) + list(af)
+            bvf = list(bv) + list(bm) + list(bf)
             avf = od(sorted(avf))
             bvf = od(sorted(bvf))
             return partial(

--- a/tests/FIXTURES/everything/a.sql
+++ b/tests/FIXTURES/everything/a.sql
@@ -44,6 +44,8 @@ create index on products(price);
 
 create view vvv as select * from products;
 
+create materialized view matvvv as select * from products;
+
 grant select, insert on table products to postgres;
 
 create or replace function public.changed(i integer, t text[])

--- a/tests/FIXTURES/everything/b.sql
+++ b/tests/FIXTURES/everything/b.sql
@@ -68,6 +68,8 @@ LANGUAGE PLPGSQL STABLE returns null on null input security invoker;
 
 create view vvv as select 2;
 
+create materialized view matvvv as select 2;
+
 CREATE TABLE bug (
     id serial,
     description text,

--- a/tests/FIXTURES/everything/expected.sql
+++ b/tests/FIXTURES/everything/expected.sql
@@ -38,6 +38,8 @@ drop index if exists "public"."products_x_key";
 
 drop function if exists "public"."changed"(i integer, t text[]) cascade;
 
+drop materialized view if exists "public"."matvvv" cascade;
+
 drop view if exists "public"."vvv" cascade;
 
 drop table "public"."aunwanted";
@@ -129,6 +131,9 @@ $$
 
 $$
 language PLPGSQL VOLATILE RETURNS NULL ON NULL INPUT SECURITY DEFINER;
+
+create materialized view "public"."matvvv" as  SELECT 2;
+
 
 create view "public"."vvv" as  SELECT 2;
 

--- a/tests/FIXTURES/everything/expected2.sql
+++ b/tests/FIXTURES/everything/expected2.sql
@@ -38,6 +38,8 @@ drop index if exists "public"."products_x_key";
 
 drop function if exists "public"."changed"(i integer, t text[]) cascade;
 
+drop materialized view if exists "public"."matvvv" cascade;
+
 drop view if exists "public"."vvv" cascade;
 
 drop table "public"."aunwanted";
@@ -125,6 +127,9 @@ $$
 
 $$
 language PLPGSQL VOLATILE RETURNS NULL ON NULL INPUT SECURITY DEFINER;
+
+create materialized view "public"."matvvv" as  SELECT 2;
+
 
 create view "public"."vvv" as  SELECT 2;
 


### PR DESCRIPTION
It would be great if migra could support materialized views.

Given that the schemainspect already supports materialized views, it looks like it should be fairly straight forward.

This PR adds the materialized views to the changes, so they appear in the diff output.
