### PR TITLE
bump schemainspect version for partitioned indexes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ homepage = "https://migra.djrobstep.com/"
 python = "*"
 sqlbag = "*"
 six = "*"
-schemainspect = ">= 0.1.1548143332"
+schemainspect = ">= 0.1.1551695490"
 psycopg2-binary = { version="*", optional = true }
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
support for postgres11 new "relkind" p = partitioned table, I = partitioned index
generating indexes for partitioned tables