### PR TITLE
docs: show how to get the tool via Docker instead of Python

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -11,6 +11,19 @@
 
     This will install the latest version of migra from PyPI (the global Python Package Index), along with psycopg2, the python PostgreSQL driver.
 
+Alternatively, if you don't want to install Python, you can run it from a 
+self-contained Docker image by first running:
+
+```shell script
+docker pull djrobstep/migra
+```
+
+then creating a short alias to it with:
+
+```shell script
+alias migra="docker run djrobstep/migra migra"
+```
+
 3. Confirm migra is installed by running `migra --help`. The output should begin like this:
 
         usage: migra [-h] [--unsafe] dburl_from dburl_target


### PR DESCRIPTION
I've been burned in the (distant) past by trying to juggle Python/PIP
versions on my dev machine, and found that migra's existing Docker image
works great as the CLI tool, *if* you know the trick to passing arguments
to it.

Without repeating the `migra` part, we get errors like this:

```text
$ docker run djrobstep/migra postgresql://user:pass@localhost:5433/src_db postgresql://user:pass@localhost:5433/target_db
/docker-entrypoint.sh: line 12: /postgresql://user:pass@localhost:5433/src_db: No such file or directory
```

It looks like passing any args overwrites the `CMD [...]` part of the Dockerfile, so inserting `migra` as the first arg fixes it:

```text
$ docker run djrobstep/migra migra postgresql://user:pass@localhost:5433/src_db postgresql://user:pass@localhost:5433/target_db
```

Not sure if the dockerfile should be modified?
https://stackoverflow.com/a/53897608/2014893 seems to have some good info.