### PR TITLE
Fix wrong homepage address in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 description = "Like `diff` but for PostgreSQL schemas"
 
 repository = "https://github.com/djrobstep/migra"
-homepage = "https://migra.djrobstep.com/"
+homepage = "https://databaseci.com/docs/migra"
 
 [tool.poetry.dependencies]
 python = ">=3.6,<4"


### PR DESCRIPTION
The old address <https://migra.djrobstep.com/> gives 522 status. It's probably outdated.  I ran into this problem because the link is used on <https://pypi.org/project/migra/>.