### PR TITLE
Add build-system section to pyproject.toml (PEP-517)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,7 @@ pg = ["psycopg2-binary"]
 multi_line_output = 3
 include_trailing_comma = true
 line_length = 88
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
According to this document <https://python-poetry.org/docs/pyproject/#poetry-and-pep-517> a `build-system` section is required in `pyproject.toml` file.

Lack of this section is part of the trouble discussed here: <https://discourse.nixos.org/t/preparing-a-nix-flake-for-a-python-program-migra-using-poetry/12030/1>.