### PR TITLE
Fix container image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM alpine:3.8
+FROM python:3.9-alpine
 
-RUN set -x && \
-    apk add --no-cache bash python3 ca-certificates postgresql-libs postgresql-dev && \
-    apk add --no-cache --virtual=build-dependencies build-base python3-dev && \
-    pip3 install --upgrade --no-cache-dir pip && \
-    pip3 install --no-cache-dir psycopg2-binary migra && \
-    apk del build-dependencies postgresql-dev python3-dev && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
+RUN apk add --update --no-cache --upgrade postgresql-libs && \
+  apk add --no-cache --virtual=build-dependencies build-base postgresql-dev && \
+  pip install --no-cache-dir packaging psycopg2-binary migra && \
+  apk del build-dependencies && \
+  rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 
 if [ "$1" = 'migra' ]; then
 	if [ "${MIGRA_LOG_COMMAND}" = 'true' ]; then
-		migra_command="$@"
-		echo "${migra_command}"
+		echo "$*"
 	fi
 fi
 


### PR DESCRIPTION
Fixes djrobstep/migra#177
Use `python:3.9-alpine` as base to reduce reliance on alpine maintainers for python and remove already provided packages (`python3`, `python3-dev`, `ca-certificates`).

Add `packaging` pip package to actually fix the build.

Remove bash since there is already a shell provided and the entrypoint-script is not using bash-exclusive syntax.
Change entrypoint-script's shebang from bash to sh & fix array-to-string assignment (see https://github.com/koalaman/shellcheck/wiki/SC2124)

Since the old Dockerfile relied on `alpine:3.8` the latest `python` version available is [3.6.9-r1](https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.8&repo=main). However I couldn't find a hard dependency on `3.6` in the project. We tested it with a really messy DB and had no issue.

Another improvement would also be to publish version-specific tags in the future. Since only `latest` was published, it's hard to fall back to earylier, working versions. This will break again in the future when dependencies change and no specific versions were tagged on the images.
