### PR TITLE
#215 use buildx to build for both amd64 and arm64.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -11,4 +11,4 @@ DOCKER_IMAGE="djrobstep/migra:latest"
 
 printf "# Image: \e[1;37m${DOCKER_IMAGE}\e[0m\n\n"
 
-docker build -t djrobstep/migra:latest .
+docker buildx build --platform linux/arm64/v8,linux/amd64 -t djrobstep/migra:latest .


### PR DESCRIPTION
I believe this small change will help enable multi platform docker images to be pushed to dockerhub.

buildx is installed on Docker for Mac + Docker for Windows

For linux you can use

```sh
#!/usr/bin/env bash

DOCKER_BUILDX_VERSION=v0.9.1

mkdir -p  $HOME/.docker/cli-plugins
curl https://github.com/docker/buildx/releases/download/${DOCKER_BUILDX_VERSION}/buildx-${DOCKER_BUILDX_VERSION}.linux-amd64 -o $HOME/.docker/cli-plugins/docker-buildx
chmod +x $HOME/.docker/cli-plugins/docker-buildx
```
