### PR TITLE
--exclude_schema -> --exclude-schema

### DIFF
--- a/migra/command.py
+++ b/migra/command.py
@@ -38,6 +38,12 @@ def parse_args(args):
         "--exclude_schema",
         dest="exclude_schema",
         default=None,
+        help="[DEPRECATED: Use --exclude-schema] Restrict output to statements for all schemas except the specified schema",
+    )
+    parser.add_argument(
+        "--exclude-schema",
+        dest="exclude_schema",
+        default=None,
         help="Restrict output to statements for all schemas except the specified schema",
     )
     parser.add_argument(


### PR DESCRIPTION
Hi there! 👋 

Big fan of migra - I'm working on a typescript/nodejs port (which as an aside, would be great to talk about if you're interested). I'm running the test fixtures to validate the port works as expected, and noticed that the CLI arg for `--exclude_schema` uses snake case where every other uses kebab case.

This adds `--exclude-schema`, and deprecates `--exclude_schema`. I'm not super familiar with argparse/python generally but I tried both out and it seems to work. My tests have a workaround but thought it'd be worth opening a pull request.

If it was intentional to use snake case for this one arg, feel free to close.